### PR TITLE
Set items in the booktree to collapsed by default

### DIFF
--- a/src/bookview.cpp
+++ b/src/bookview.cpp
@@ -129,6 +129,10 @@ RET_SEARCH BookView::newPage(QWidget *parent, const Query& query, bool newTab,
 
     RET_SEARCH retStatus = page->search(query);
 
+    // Collapse the book tree by default.
+    // This makes jumping between books easier.
+    page->collapseBookTree();
+
     QWidget *focus_page = 0;
     BookView *view = this;
     if (retStatus == NORMAL) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,6 +51,7 @@
 #include <QTimer>
 #include <QToolBar>
 #include <QWebEngineHistory>
+#include <QTextStream>
 
 const char *Program = { "qolibri" };
 
@@ -122,6 +123,8 @@ void MainWindow::createActions()
     toggleWatchClipboardAct->setIconVisibleInMenu(false);
     toggleWatchClipboardAct->setIcon(QIcon(":/images/paste.png"));
     connect(toggleWatchClipboardAct, &QAction::toggled, this, &MainWindow::connectClipboard);
+    copyTabListAct = new QAction(tr("Copy list of open tabs"), this);
+    connect(copyTabListAct, &QAction::triggered, this, &MainWindow::copyTabList);
 }
 
 void MainWindow::createMenus()
@@ -191,6 +194,7 @@ void MainWindow::createMenus()
                                       tr("Bookmark"),
                                       this, SLOT(addMark()));
     toolsMenu->addAction(toggleWatchClipboardAct);
+    toolsMenu->addAction(copyTabListAct);
 
     CONNECT_BUSY(addMarkAct);
     toggleTabsAct = toolsMenu->addAction(QIcon(":/images/tabs.png"),
@@ -1297,6 +1301,22 @@ void MainWindow::connectClipboard(bool enable)
         });
     } else
         clipboard->disconnect(SIGNAL(changed(QClipboard::Mode)));
+}
+
+void MainWindow::copyTabList()
+{
+    QString resultString;
+    QTextStream stream(&resultString);
+    // Iterate through tabs and append their titles to the list
+    for (int i = 0; i < bookView->count(); ++i)
+    {
+        QString tabTitle = bookView->tabText(i);
+        stream << tabTitle << Qt::endl;
+    }
+
+    // Paste the list into the clipboard.
+    auto* const clipboard = QApplication::clipboard();
+    clipboard->setText(resultString);
 }
 
 void MainWindow::aboutQolibri()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -61,6 +61,7 @@ public slots:
 
 private slots:
     void connectClipboard(bool enable);
+    void copyTabList();
     void viewInfo(Book *book);
     void viewPseudoSearch(SearchDirection direction);
     void viewSearch();
@@ -152,6 +153,7 @@ private:
     QAction *toggleMethodBarAct;
     QAction *toggleBookTreeAct;
     QAction *toggleWatchClipboardAct;
+    QAction *copyTabListAct;
     QAction *booksAct;
     QAction *configAct;
     QAction *sSheetAct;

--- a/src/pagewidget.cpp
+++ b/src/pagewidget.cpp
@@ -39,6 +39,16 @@ PageWidget::PageWidget(QWidget *parent, const SearchMethod &method)
             SLOT(popupSlide(QPoint)));
 }
 
+void PageWidget::collapseBookTree()
+{
+    try {
+        QTreeWidgetItem* root = bookTree->topLevelItem(0);
+        for (int i = 0; i < root->childCount(); i++) {
+                root->child(i)->setExpanded(false);
+        }
+    } catch (...) {};
+}
+
 bool PageWidget::checkStop()
 {
     QEventLoop().processEvents();

--- a/src/pagewidget.h
+++ b/src/pagewidget.h
@@ -16,6 +16,8 @@ public:
 
     virtual RET_SEARCH search(const Query&) = 0;
 
+    void collapseBookTree();
+
     void zoomIn();
     void zoomOut();
     BookBrowser* bookBrowser()


### PR DESCRIPTION
Having all books collapsed by default makes it much easier to jump between them.
I think this is a more frequently needed requirement than seeing all matches.