### PR TITLE
Add feature to copy a list of all opened tabs

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,6 +51,7 @@
 #include <QTimer>
 #include <QToolBar>
 #include <QWebEngineHistory>
+#include <QTextStream>
 
 const char *Program = { "qolibri" };
 
@@ -122,6 +123,8 @@ void MainWindow::createActions()
     toggleWatchClipboardAct->setIconVisibleInMenu(false);
     toggleWatchClipboardAct->setIcon(QIcon(":/images/paste.png"));
     connect(toggleWatchClipboardAct, &QAction::toggled, this, &MainWindow::connectClipboard);
+    copyTabListAct = new QAction(tr("Copy list of open tabs"), this);
+    connect(copyTabListAct, &QAction::triggered, this, &MainWindow::copyTabList);
 }
 
 void MainWindow::createMenus()
@@ -191,6 +194,7 @@ void MainWindow::createMenus()
                                       tr("Bookmark"),
                                       this, SLOT(addMark()));
     toolsMenu->addAction(toggleWatchClipboardAct);
+    toolsMenu->addAction(copyTabListAct);
 
     CONNECT_BUSY(addMarkAct);
     toggleTabsAct = toolsMenu->addAction(QIcon(":/images/tabs.png"),
@@ -1297,6 +1301,22 @@ void MainWindow::connectClipboard(bool enable)
         });
     } else
         clipboard->disconnect(SIGNAL(changed(QClipboard::Mode)));
+}
+
+void MainWindow::copyTabList()
+{
+    QString resultString;
+    QTextStream stream(&resultString);
+    // Iterate through tabs and append their titles to the list
+    for (int i = 0; i < bookView->count(); ++i)
+    {
+        QString tabTitle = bookView->tabText(i);
+        stream << tabTitle << Qt::endl;
+    }
+
+    // Paste the list into the clipboard.
+    auto* const clipboard = QApplication::clipboard();
+    clipboard->setText(resultString);
 }
 
 void MainWindow::aboutQolibri()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -61,6 +61,7 @@ public slots:
 
 private slots:
     void connectClipboard(bool enable);
+    void copyTabList();
     void viewInfo(Book *book);
     void viewPseudoSearch(SearchDirection direction);
     void viewSearch();
@@ -152,6 +153,7 @@ private:
     QAction *toggleMethodBarAct;
     QAction *toggleBookTreeAct;
     QAction *toggleWatchClipboardAct;
+    QAction *copyTabListAct;
     QAction *booksAct;
     QAction *configAct;
     QAction *sSheetAct;


### PR DESCRIPTION
# Background
In busy times, lots of open tabs with word look-ups accumulate and wait for being checked and potentially added to my SRS. However, system updates etc. sometimes require the entire system to be rebooted. It can then take quite a while to manually go through all open tabs before qolibri can be closed.

# Feature
This PR adds an action called "Copy list of open tabs" to the tools menu which copies a list of the titles of all currently opened tabs to the user's clipboard. With this, I we can quickly save the state of qolibri in a text file etc. and then review it later when we have time.

# Outlook
All in all it would probably be best to have an option to auto-save opened tabs and auto-recover them after starting qolibri again. This is just the first step to avoid users losing data during a reboot. (Technically, there is still the history, but it also contains closed tabs, cannot be directly exported, and requires the user to remember how far to check it.)