### PR TITLE
Set items in the booktree to collapsed by default

### DIFF
--- a/src/bookview.cpp
+++ b/src/bookview.cpp
@@ -129,6 +129,10 @@ RET_SEARCH BookView::newPage(QWidget *parent, const Query& query, bool newTab,
 
     RET_SEARCH retStatus = page->search(query);
 
+    // Collapse the book tree by default.
+    // This makes jumping between books easier.
+    page->collapseBookTree();
+
     QWidget *focus_page = 0;
     BookView *view = this;
     if (retStatus == NORMAL) {

--- a/src/pagewidget.cpp
+++ b/src/pagewidget.cpp
@@ -39,6 +39,16 @@ PageWidget::PageWidget(QWidget *parent, const SearchMethod &method)
             SLOT(popupSlide(QPoint)));
 }
 
+void PageWidget::collapseBookTree()
+{
+    try {
+        QTreeWidgetItem* root = bookTree->topLevelItem(0);
+        for (int i = 0; i < root->childCount(); i++) {
+                root->child(i)->setExpanded(false);
+        }
+    } catch (...) {};
+}
+
 bool PageWidget::checkStop()
 {
     QEventLoop().processEvents();

--- a/src/pagewidget.h
+++ b/src/pagewidget.h
@@ -16,6 +16,8 @@ public:
 
     virtual RET_SEARCH search(const Query&) = 0;
 
+    void collapseBookTree();
+
     void zoomIn();
     void zoomOut();
     BookBrowser* bookBrowser()


### PR DESCRIPTION
Having all books collapsed by default makes it much easier to jump between them. I think this is a more frequently needed requirement than seeing all matches.